### PR TITLE
Section 8 labs update

### DIFF
--- a/container-bootcamp/section-8-labs/README.md
+++ b/container-bootcamp/section-8-labs/README.md
@@ -96,11 +96,7 @@ Some typical uses of a DaemonSet are:
 
 In this case, we will deploy the fluentd pods as a DaemonSet.
 
-Switch to the Section 8 directory where the `fluentd-daemonset.yml` file is located:
-
-`cd /ab/labs/container-bootcamp/section-8-labs/`
-
-Now lets deploy `fluentd-daemonset.yml`:
+Lets deploy `fluentd-daemonset.yml`:
 
 `kubectl apply -f fluentd-daemonset.yml -n training-lab`
 

--- a/container-bootcamp/section-8-labs/README.md
+++ b/container-bootcamp/section-8-labs/README.md
@@ -72,6 +72,10 @@ Cleanup the StatefulSet:
 
 `kubectl delete -f nginx-statefulset.yml -n training-lab`
 
+Verify the training-lab namespace has no resources deployed:
+
+`kubectl get all -n training-lab`
+
 ____
 
 ## Section 8: Lab 2 - DaemonSets

--- a/container-bootcamp/section-8-labs/README.md
+++ b/container-bootcamp/section-8-labs/README.md
@@ -104,17 +104,19 @@ View the pods that were created. Notice that it automatically created 3 and dist
 
 `kubectl get pods -n training-lab -o wide`
 
-Note there are 4 running because there is 1 server and 3 worker nodes, so 1 fluentd pod for each.. When we ran a Deployment or StatefulSet, we had to manually scale or update the manifest to change the number of pods. Let's deploy a new K3d worker node and see what happens.
+Note there are 4 running because there is 1 server and 3 worker nodes, so 1 fluentd pod for each. When we ran a Deployment or StatefulSet, we had to manually scale or update the manifest to change the number of pods. Let's deploy a new K3d worker node and see what happens.
 
 Add another K3d worker node:
 
 `k3d node create lab-cluster-agent-3 --cluster lab-cluster`
 
-Check pods:
+It will take a moment to add the agent and create the associated pod.  Let's `watch` the pod being created:
 
-`kubectl get pods -n training-lab -o wide`
+`watch kubectl get pods -n training-lab -o wide`
 
 Note that there are now 5 pods. Kubernetes automatically scaled the DaemonSet and deployed a fluentd pod on the new worker node.
+
+Press `Ctrl + C` to exit the `watch` command.
 ____
 
 ### Congrats! You have completed the Section 8 labs. You may now proceed with the rest of the course.

--- a/container-bootcamp/section-8-labs/README.md
+++ b/container-bootcamp/section-8-labs/README.md
@@ -62,7 +62,11 @@ We can also see that persistent volumes (more on those in a later section) have 
 
 `kubectl get pvc -n training-lab`
 
-Lastly, if you look at the `nginx-statefulset.yml` file, we also had to create a service. That is because StatefulSets currently require a Headless Service to be responsible for the network identity of the Pods. (More on Services in a later lab as well).
+Lastly, if you look at the `nginx-statefulset.yml` file on lines 1 through 13, we created a service. That is because StatefulSets currently require a Headless Service to be responsible for the network identity of the Pods. (More on Services in a later lab as well).
+
+Let's take a look at the deployed service:
+
+`kubectl get svc -n training-lab -o wide`
 
 Cleanup the StatefulSet:
 


### PR DESCRIPTION
* Clarified section to review in nginx-statefulset.yml file.
* Added a check to show the namespace had no running resources after removal of resources.
* Removed redundant directory change.
* Added watch command to get pods after adding a new agent due to speed to help avoid confusion.